### PR TITLE
Add host fallback for tests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Build Docker Image
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker
+          push: false
+          tags: test/asterisk:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,14 +14,15 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
         uses: docker/build-push-action@v4
         with:
           context: ./docker
-          push: false
-          tags: test/asterisk:latest
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/asterisk:latest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Asterisk Container for Building Intercom
+
+This repository contains a minimal Asterisk setup that can be deployed in a Docker container. It is intended to connect an Intelbras analog PBX to Asterisk through a Grandstream HT812 gateway.
+
+## Building the Image
+
+```bash
+docker build -t asterisk docker
+```
+
+## Running the Container
+
+```bash
+docker run -p 5060:5060/udp asterisk
+```
+
+Configuration files live in `docker/config` and define a simple IVR that maps digits 1-4 to apartment extensions 201, 202, 301, and 302 via the HT812.
+
+## Tests
+
+Automated tests can be executed with:
+
+```bash
+./tests/test_container.sh
+```
+
+The script attempts to run the Asterisk container if Docker is available. If Docker is not present, it starts a temporary Asterisk instance directly on the host using the sample configuration.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,24 @@
 
 This repository contains a minimal Asterisk setup that can be deployed in a Docker container. It is intended to connect an Intelbras analog PBX to Asterisk through a Grandstream HT812 gateway.
 
+The provided GitHub Actions workflow builds the container image and pushes it to GitHub Container Registry (GHCR) whenever changes are pushed or a pull request is opened.
+
 ## Building the Image
 
 ```bash
 docker build -t asterisk docker
 ```
 
+Or pull the image built by GitHub Actions:
+
+```bash
+docker pull ghcr.io/<owner>/asterisk:latest
+```
+
 ## Running the Container
 
 ```bash
-docker run -p 5060:5060/udp asterisk
+docker run -p 5060:5060/udp ghcr.io/<owner>/asterisk:latest
 ```
 
 Configuration files live in `docker/config` and define a simple IVR that maps digits 1-4 to apartment extensions 201, 202, 301, and 302 via the HT812.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:bullseye-slim
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y asterisk && \
+    rm -rf /var/lib/apt/lists/*
+COPY config/ /etc/asterisk/
+CMD ["/usr/sbin/asterisk", "-f", "-U", "asterisk", "-vvv"]

--- a/docker/config/extensions.conf
+++ b/docker/config/extensions.conf
@@ -1,0 +1,24 @@
+[general]
+static=yes
+writeprotect=no
+
+[default]
+exten => s,1,Answer()
+ same => n,Wait(1)
+ same => n,Background(enter-ext-of-person)
+ same => n,WaitExten(10)
+ same => n,Hangup()
+
+exten => 1,1,Goto(201,1)
+exten => 2,1,Goto(202,1)
+exten => 3,1,Goto(301,1)
+exten => 4,1,Goto(302,1)
+
+exten => 201,1,Dial(PJSIP/201@ht812,30)
+ same => n,Hangup()
+exten => 202,1,Dial(PJSIP/202@ht812,30)
+ same => n,Hangup()
+exten => 301,1,Dial(PJSIP/301@ht812,30)
+ same => n,Hangup()
+exten => 302,1,Dial(PJSIP/302@ht812,30)
+ same => n,Hangup()

--- a/docker/config/modules.conf
+++ b/docker/config/modules.conf
@@ -1,0 +1,2 @@
+[modules]
+autoload=yes

--- a/docker/config/pjsip.conf
+++ b/docker/config/pjsip.conf
@@ -1,0 +1,21 @@
+[global]
+user_agent=Asterisk Building
+
+[transport-udp]
+type=transport
+protocol=udp
+bind=0.0.0.0
+
+[ht812]
+; Grandstream HT812 SIP trunk
+ type=endpoint
+ transport=transport-udp
+ context=default
+ disallow=all
+ allow=ulaw
+ aors=ht812
+
+[ht812]
+ type=aor
+ contact=sip:ht812:5060
+

--- a/tests/test_container.sh
+++ b/tests/test_container.sh
@@ -11,6 +11,11 @@ if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   docker exec $CONTAINER_ID asterisk -rx "dialplan show default"
 else
   echo "Running host-based test"
+  if ! command -v asterisk >/dev/null 2>&1; then
+    echo "Installing Asterisk"
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y asterisk >/dev/null
+  fi
   TMPDIR=$(mktemp -d)
   mkdir -p "$TMPDIR"/{var,db,keys,spool,run,log}
   cp docker/config/*.conf "$TMPDIR/"

--- a/tests/test_container.sh
+++ b/tests/test_container.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+IMAGE=asterisk-test
+
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  echo "Running Docker-based test"
+  docker build -t $IMAGE docker
+  CONTAINER_ID=$(docker run -d -p 5060:5060/udp $IMAGE)
+  trap "docker rm -f $CONTAINER_ID" EXIT
+  sleep 5
+  docker exec $CONTAINER_ID asterisk -rx "dialplan show default"
+else
+  echo "Running host-based test"
+  TMPDIR=$(mktemp -d)
+  mkdir -p "$TMPDIR"/{var,db,keys,spool,run,log}
+  cp docker/config/*.conf "$TMPDIR/"
+  cat > "$TMPDIR/asterisk.conf" <<CONF
+[directories]
+astetcdir => $TMPDIR
+astmoddir => /usr/lib/x86_64-linux-gnu/asterisk/modules
+astvarlibdir => $TMPDIR/var
+astdbdir => $TMPDIR/db
+astkeydir => $TMPDIR/keys
+astdatadir => /usr/share/asterisk
+astagidir => /usr/share/asterisk/agi-bin
+astspooldir => $TMPDIR/spool
+astrundir => $TMPDIR/run
+astlogdir => $TMPDIR/log
+CONF
+
+  asterisk -C "$TMPDIR/asterisk.conf" -f -vvv >/tmp/asterisk.log 2>&1 &
+  ASTPID=$!
+  trap "kill $ASTPID" EXIT
+  sleep 5
+  asterisk -C "$TMPDIR/asterisk.conf" -rx "dialplan show default"
+fi


### PR DESCRIPTION
## Summary
- adjust test script to run even when Docker isn't available
- update README to mention host-based fallback

## Testing
- `bash tests/test_container.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f2cbdff2c8326b68fb6a8e721011e